### PR TITLE
Rename dependency on glib-utils to glib

### DIFF
--- a/Formula/pspp.rb
+++ b/Formula/pspp.rb
@@ -7,7 +7,7 @@ class Pspp < Formula
 
   option "with-relocation", "Build a relocatable application which is required for a bundle"
 
-  depends_on "glib-utils" => :build
+  depends_on "glib" => :build
   depends_on "gtk+3"
   depends_on "gtksourceview4"
   depends_on "adwaita-icon-theme"

--- a/Formula/spread-sheet-widget.rb
+++ b/Formula/spread-sheet-widget.rb
@@ -5,7 +5,7 @@ class SpreadSheetWidget < Formula
   sha256 "8589d8298fcf3b5850d0968b04801a4f40faf0555544f6cc9d954b0162e9954b"
 
   depends_on "pkg-config" => :build
-  depends_on "glib-utils" => :build
+  depends_on "glib" => :build
   depends_on "gtk+3"
 
   def install


### PR DESCRIPTION
Rename dependency on glib-utils to glib, as name has changed https://formulae.brew.sh/formula/glib